### PR TITLE
made the delete button functional

### DIFF
--- a/Services/AppleMusicAdder.cs
+++ b/Services/AppleMusicAdder.cs
@@ -233,4 +233,57 @@ public class AppleMusicAdder
         await proc.WaitForExitAsync();
         int exitCode = proc.ExitCode;
     }
+
+    public static async Task DeletePlaylistFromMusic(PlaylistViewModel pl_vm){ 
+        
+        string delete_playlist_from_music = $"""
+                set playlistToDelete to "{pl_vm.Title}"
+                tell application "Music"
+                    set targetPlaylist to user playlist playlistToDelete
+                    set trackList to every track of targetPlaylist
+                    
+                    
+                    repeat with t in trackList
+                        set tName to name of t
+                        set trackInLibrary to (first track of library playlist 1 whose name is tName)
+                        
+                        set trackDiskLocation to location of trackInLibrary
+                        if trackDiskLocation is not missing value then
+                            
+                            set trackPath to POSIX path of (trackDiskLocation as text)
+                            delete trackInLibrary
+                            do shell script "rm -f " & quoted form of trackPath
+                            
+                        end if
+                        
+                    end repeat
+                    delete targetPlaylist
+                    
+                end tell
+            """;
+
+        ProcessStartInfo subprocess = new()
+        {
+            FileName = "osascript",
+            ArgumentList = { "-e", delete_playlist_from_music},
+            CreateNoWindow = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+        var proc = Process.Start(subprocess);
+        ArgumentNullException.ThrowIfNull(proc);
+
+        //Send Console Output to UI
+        var outputTask = Task.Run(async () =>
+        {
+            while (!proc.StandardOutput.EndOfStream)
+            {
+                var line = await proc.StandardOutput.ReadLineAsync();
+                Console.WriteLine(line);
+            }
+        });
+
+        await proc.WaitForExitAsync();
+        int exitCode = proc.ExitCode;
+    }
 }

--- a/Styles/AppDefaultStyles.axaml
+++ b/Styles/AppDefaultStyles.axaml
@@ -74,11 +74,134 @@
         <Setter Property="FontSize" Value="25"></Setter>
         <Setter Property="TextWrapping" Value="Wrap"></Setter>
 </Style>
+
 <Style Selector="Button.PlaylistViewButton">
         <Setter Property="HorizontalAlignment" Value="Center"></Setter>
         <Setter Property="FontSize" Value="16"></Setter>
         <Setter Property="Margin" Value="5,0,5,5"></Setter>
 </Style>
+
+<Style Selector="Button.PlaylistViewButtonFinder">
+        <Setter Property="HorizontalAlignment" Value="Center"></Setter>
+        <Setter Property="FontSize" Value="16"></Setter>
+        <Setter Property="Margin" Value="5,0,5,5"></Setter>
+        <Setter Property="Background">
+                <Setter.Value>
+                        <LinearGradientBrush StartPoint="50%,0%" EndPoint="50%,100%">
+                                <GradientStop Color="#4bbad8" Offset="0.0"/>
+                                <GradientStop Color="#f1f0eb" Offset="0.5"/>
+                                <GradientStop Color="#4bbad8" Offset="1.0"/>
+                        </LinearGradientBrush>
+                </Setter.Value>
+        </Setter>
+</Style>
+<Style Selector="Button.PlaylistViewButtonFinder:pointerover /template/ ContentPresenter">
+        <Setter Property="HorizontalAlignment" Value="Center"></Setter>
+        <Setter Property="FontSize" Value="16"></Setter>
+        <Setter Property="Background">
+                <Setter.Value>
+                        <LinearGradientBrush StartPoint="50%,0%" EndPoint="50%,100%">
+                                <GradientStop Color="#3589a0" Offset="0.0"/>
+                                <GradientStop Color="#f1f0eb" Offset="0.5"/>
+                                <GradientStop Color="#3589a0" Offset="1.0"/>
+                        </LinearGradientBrush>
+                </Setter.Value>
+        </Setter>
+</Style>
+
+
+<Style Selector="Button.PlaylistViewButtonMusic:pointerover /template/ ContentPresenter">
+        <Setter Property="HorizontalAlignment" Value="Center"></Setter>
+        <Setter Property="FontSize" Value="16"></Setter>
+        <Setter Property="Background">
+                <Setter.Value>
+                        <LinearGradientBrush StartPoint="50%,0%" EndPoint="50%,100%">
+                                <GradientStop Color="#b91829" Offset="0.0"/>
+                                <GradientStop Color="#f1f0eb" Offset="0.5"/>
+                                <GradientStop Color="#b91829" Offset="1.0"/>
+                        </LinearGradientBrush>
+                </Setter.Value>
+        </Setter>
+</Style>
+
+<Style Selector="Button.PlaylistViewButtonMusic">
+        <Setter Property="HorizontalAlignment" Value="Center"></Setter>
+        <Setter Property="FontSize" Value="16"></Setter>
+        <Setter Property="Margin" Value="5,0,5,5"></Setter>
+        <Setter Property="Background">
+                <Setter.Value>
+                        <LinearGradientBrush StartPoint="50%,0%" EndPoint="50%,100%">
+                                <GradientStop Color="#f9243b" Offset="0.0"/>
+                                <GradientStop Color="#f1f0eb" Offset="0.5"/>
+                                <GradientStop Color="#f9243b" Offset="1.0"/>
+                        </LinearGradientBrush>
+                </Setter.Value>
+        </Setter>
+</Style>
+
+
+
+<Style Selector="Button.PlaylistViewButtonDownload">
+        <Setter Property="HorizontalAlignment" Value="Center"></Setter>
+        <Setter Property="FontSize" Value="16"></Setter>
+        <Setter Property="Margin" Value="5,0,5,5"></Setter>
+        <Setter Property="Foreground" Value="White"></Setter>
+        <Setter Property="Background">
+                <Setter.Value>
+                        <LinearGradientBrush StartPoint="50%,0%" EndPoint="50%,100%">
+                                <GradientStop Color="#33FF33" Offset="0.0"/>
+                                <GradientStop Color="#068006" Offset="0.5"/>
+                                <GradientStop Color="#33FF33" Offset="1.0"/>
+                        </LinearGradientBrush>
+                </Setter.Value>
+        </Setter>
+</Style>
+
+<Style Selector="Button.PlaylistViewButtonDownload:pointerover /template/ ContentPresenter">
+        <Setter Property="HorizontalAlignment" Value="Center"></Setter>
+        <Setter Property="FontSize" Value="16"></Setter>
+        <Setter Property="Foreground" Value="White"></Setter>
+        <Setter Property="Background">
+                <Setter.Value>
+                        <LinearGradientBrush StartPoint="50%,0%" EndPoint="50%,100%">
+                                <GradientStop Color="#068006" Offset="0.0"/>
+                                <GradientStop Color="#33FF33" Offset="0.5"/>
+                                <GradientStop Color="#068006" Offset="1.0"/>
+                        </LinearGradientBrush>
+                </Setter.Value>
+        </Setter>
+</Style>
+
+
+<Style Selector="Button.PlaylistViewButtonCheck">
+        <Setter Property="HorizontalAlignment" Value="Center"></Setter>
+        <Setter Property="FontSize" Value="16"></Setter>
+        <Setter Property="Margin" Value="5,0,5,5"></Setter>
+        <Setter Property="Background">
+                <Setter.Value>
+                        <LinearGradientBrush StartPoint="50%,0%" EndPoint="50%,100%">
+                                <GradientStop Color="#FFEA00" Offset="0.0"/>
+                                <GradientStop Color="#dcbd0a" Offset="0.5"/>
+                                <GradientStop Color="#FFEA00" Offset="1.0"/>
+                        </LinearGradientBrush>
+                </Setter.Value>
+        </Setter>
+</Style>
+
+<Style Selector="Button.PlaylistViewButtonCheck:pointerover /template/ ContentPresenter">
+        <Setter Property="HorizontalAlignment" Value="Center"></Setter>
+        <Setter Property="FontSize" Value="16"></Setter>
+        <Setter Property="Background">
+                <Setter.Value>
+                        <LinearGradientBrush StartPoint="50%,0%" EndPoint="50%,100%">
+                                <GradientStop Color="#dcbd0a" Offset="0.0"/>
+                                <GradientStop Color="#FFEA00" Offset="0.5"/>
+                                <GradientStop Color="#dcbd0a" Offset="1.0"/>
+                        </LinearGradientBrush>
+                </Setter.Value>
+        </Setter>
+</Style>
+
 <Style Selector="TextBlock.PlaylistViewProperties">
         <Setter Property="FontSize" Value="14"></Setter>
         <Setter Property="Margin" Value="5"></Setter>

--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -263,6 +263,28 @@ public partial  class MainWindowViewModel : ViewModelBase
         SetAlbumArt(pl);
     }
 
+    [RelayCommand]
+    public async Task DeleteThisPlaylist(PlaylistViewModel plvm)
+    {
+        await AppleMusicAdder.DeletePlaylistFromMusic(plvm);
+        System.IO.Directory.Delete(plvm.Mp3_path, true);
+        System.IO.File.Delete(plvm.Archive_path);
+        await DbConnection.DeletePlaylist(plvm.Id);
+
+        if (SearchResults.Contains(plvm))
+        {
+            SearchResults.Remove(plvm);
+        }
+        if (PlaylistViewModels.Contains(plvm))
+        {
+            PlaylistViewModels.Remove(plvm);
+        }
+
+        PlaylistSelected = false;
+        SelectedPlaylist = null;
+
+    }
+
     public void SetAlbumArt(PlaylistViewModel plvm)
     {
         string? first_song_path = getFirstSongPath(plvm);

--- a/Views/MainWindow.axaml
+++ b/Views/MainWindow.axaml
@@ -71,20 +71,22 @@
                         </StackPanel>
                     </Grid>
                         <Grid Row="2" ColumnDefinitions="Auto,Auto,Auto,Auto,Auto">
-                            <Button Grid.Column="0" Classes="PlaylistViewButton" Command="{Binding #Root.((vm:MainWindowViewModel)DataContext).CheckPlaylist}"
+                            <Button Grid.Column="0" Classes="PlaylistViewButtonCheck" Command="{Binding #Root.((vm:MainWindowViewModel)DataContext).CheckPlaylist}"
                                     CommandParameter="{Binding .}"
                                     >
                             Check For Updates</Button>
                             <Button Grid.Column="1"   
-                                    Classes="PlaylistViewButton" 
+                                    Classes="PlaylistViewButtonDownload" 
                                     Command="{Binding #Root.((vm:MainWindowViewModel)DataContext).DownloadAndAddPlaylist}"
                                     CommandParameter="{Binding .}"> 
                                 Download</Button>
-                            <Button Grid.Column="2" Classes="PlaylistViewButton"  Content="Delete"></Button>
-                            <Button Grid.Column="3" Classes="PlaylistViewButton"   Content="Show in Finder"
+                            <Button Grid.Column="2" Classes="PlaylistViewButton"  Content="Delete"
+                                    Command="{Binding #Root.((vm:MainWindowViewModel)DataContext).DeleteThisPlaylist}"
+                                    CommandParameter="{Binding .}"></Button>
+                            <Button Grid.Column="3" Classes="PlaylistViewButtonFinder"   Content="Show in Finder"
                                     Command="{Binding #Root.((vm:MainWindowViewModel)DataContext).OpenSelectedPlaylistFinder}"
                                     CommandParameter="{Binding .}"></Button>
-                            <Button Grid.Column="4" Classes="PlaylistViewButton"   Content="Show in Music"
+                            <Button Grid.Column="4" Classes="PlaylistViewButtonMusic"   Content="Show in Music"
                                     Command="{Binding #Root.((vm:MainWindowViewModel)DataContext).OpenSelectedPlaylistMusic}"
                                     CommandParameter="{Binding .}"></Button>
                         </Grid>


### PR DESCRIPTION
Turns out we didn't need to keep track of songs (Thank God!) since AppleScript can trawl through the songs and give us a POSIX path of each song's location within Musics directory on the disk. It's bad practice to be editing those files directly but I don't know any other way to fully remove the song from Music without it, since commands like "Delete {trackname}" only delete the song from the library playlist, but don't remove the underlying file thats written to the disk, which is an incredibly stupid implementation of a command as vague as "delete". 

Benchmarking: I thought it would be slow, because all my Applescripts are run through a subprocess and we are now calling shell scripts for each song involved the subprocess, (its gross IK), but calling the whole function takes around 0.05 seconds on a normally sized playlist, which is fast enough for our purposes. This approach is likely faster than having to scrape each playlist before downloading to get the titles of each video in order to throw the video info into a row in the DB, which would be a prerequisite of deleting playlists (we would need to keep track of each filepath of every song in every playlist in the DB, which means getting the names at download time because the actual files YT2ITUNES would store would be in UUID format, not the actual video title, and all this means you need a database of your videos in addition to your playlists). Further, getting all this info it be executed at the time of download and infinitely slower because its a web request. So Im fine with this approach. 

Also, styled the buttons on the playlist viewers with color gradients


TLDR; I hate AppleScript its awesome. 